### PR TITLE
README.md: add note about certificate expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ You now have your exported certificate and private key stored in two separate PE
 
 Copy these two files to your Dovecot server.
 
+NOTE: APNS certificates expire 1 year after they were originally issued by Apple, so they will need to be renewed or regenerated through the OS X Server application each year. Expiration information for these certificates can be found at the [Apple Push Certificates Portal](https://identity.apple.com/pushcert/).
+
 Installing and Running the Daemon
 ---------------------------------
 


### PR DESCRIPTION
I was excited to setup this software hoping I could just install OS X server temporarily, generate the certificate, export it, and then delete OS X Server, but these certificates only last a year.

The Apple Push Certificates Portal allows uploading CSRs and issuing certificates without having to use the OS X Server app, which would make all of this a much nicer process for those that did not migrate from OS X Server.

However, those CSRs need to be signed by an MDM partner in order to be accepted by the website.  I'm not sure what it takes to become an MDM partner (paying the $200/year to be an Enterprise iOS Developer?).