### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Compiling and Installing the Daemon
 The daemon is written in Go. The easiest way to build it is with the [GB] (http://getgb.io/docs/install/) tool.
 
 ```
-git checkout https://github.com/st3fan/dovecot-xaps-daemon.git
+git clone https://github.com/st3fan/dovecot-xaps-daemon.git
 cd dovecot-xaps-daemon
 gb build all
 ```


### PR DESCRIPTION
```
$ git checkout https://github.com/st3fan/dovecot-xaps-daemon.git
fatal: Not a git repository (or any of the parent directories): .git

$ git clone https://github.com/st3fan/dovecot-xaps-daemon.git
Cloning into 'dovecot-xaps-daemon'...
remote: Counting objects: 248, done.
remote: Total 248 (delta 0), reused 0 (delta 0), pack-reused 248
Receiving objects: 100% (248/248), 64.17 KiB | 6.00 KiB/s, done.
Resolving deltas: 100% (98/98), done.
Checking connectivity... done.
```