### PR TITLE
Remove trailing whitespace in systemd unit

### DIFF
--- a/etc/systemd/xapsd.service
+++ b/etc/systemd/xapsd.service
@@ -11,7 +11,7 @@ ExecStart=/usr/bin/xapsd -key=/etc/xapsd/${KEY_FILE} \
                          -socket=/var/run/dovecot/xapsd.sock \
                          -loglevel=${LOGLEVEL} \
                          -delayCheckInterval=${CHECKINTERVAL} \
-                         -delayTime=${DELAY} \ 
+                         -delayTime=${DELAY} \
                          -feedbackInterval=${FEEDBACK_INTERVAL} \
                          -redisEnabled=${REDIS_ENABLED} \
                          -redisUrl=${REDIS_URL} \


### PR DESCRIPTION
The trailing whitespace seems to confuse systemd (v219) here:

```
Jul 09 03:54:45 mailin01.mx.bawue.net systemd[1]: [/usr/lib/systemd/system/xapsd.service:8] Trailing garbage, ignoring.
Jul 09 03:54:45 mailin01.mx.bawue.net systemd[1]: [/usr/lib/systemd/system/xapsd.service:9] Unknown lvalue '-feedbackInterval' in section 'Service'
Jul 09 03:54:45 mailin01.mx.bawue.net systemd[1]: xapsd.service lacks both ExecStart= and ExecStop= setting. Refusing.
```